### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Utility to detect/verify happytiffs",
   "main": "index.js",
   "author": "Mapbox (https://www.mapbox.com)",
+  "repository": "https://github.com/mapbox/node-happytiff.git"
   "dependencies": {
     "mapnik-omnivore": "~6.2.0",
     "minimist": "1.1.x",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utility to detect/verify happytiffs",
   "main": "index.js",
   "author": "Mapbox (https://www.mapbox.com)",
-  "repository": "https://github.com/mapbox/node-happytiff.git"
+  "repository": "https://github.com/mapbox/node-happytiff.git",
   "dependencies": {
     "mapnik-omnivore": "~6.2.0",
     "minimist": "1.1.x",


### PR DESCRIPTION
Get's rid of warnings we see during `npm install` for `pxm`.

/cc @GretaCB happy to merge if it's cool.
