### PR TITLE
test node 4 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - "0.10"
+- "4"
 sudo: false
 
 before_install:

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -14,7 +14,7 @@ tape('usage', function(assert) {
 tape('proxies err', function(assert) {
     execFile(binPath, ['/does/not/exist.tif'], function(err, stdout, stderr) {
         assert.equal(err.code, 3);
-        assert.equal(stderr, 'Error: ENOENT, open \'/does/not/exist.tif\'\n');
+        assert.ok(stderr.indexOf('ENOENT') > -1);
         assert.end();
     });
 });


### PR DESCRIPTION
This updates the `.travis.yml` file to include node 4. I had to update one test that was asserting on a complete error message string, which has changed in node 4. Now using `.indexOf` to assert that the error code is the same. 

note: cannot test `err.code` since the whole err is stringified prior to landing in `stderr`
