### PR TITLE
Bump to 1.0.0, update to mapnik 3.7.0 via mapnik-omnivore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.0
+
+- Upgrade to mapnik-omnivore@8.6.0
+
 # 0.10.0
 
 - Upgrade to mapnik-omnivore@8.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.11.0
+# 1.0.0
 
-- Upgrade to mapnik-omnivore@8.6.0
+- Upgrade to mapnik-omnivore@9.0.0
+- Drops windows support
 
 # 0.10.0
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/happytiff",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Utility to detect/verify happytiffs",
   "main": "index.js",
   "author": "Mapbox (https://www.mapbox.com)",
   "repository": "https://github.com/mapbox/node-happytiff.git",
   "dependencies": {
-    "@mapbox/mapnik-omnivore": "~8.5.0",
+    "@mapbox/mapnik-omnivore": "~8.6.0",
     "@mapbox/sphericalmercator": "1.0.x",
     "minimist": "1.1.x"
   },

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/happytiff",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "description": "Utility to detect/verify happytiffs",
   "main": "index.js",
   "author": "Mapbox (https://www.mapbox.com)",
   "repository": "https://github.com/mapbox/node-happytiff.git",
   "dependencies": {
-    "@mapbox/mapnik-omnivore": "~8.6.0",
+    "@mapbox/mapnik-omnivore": "~9.0.0",
     "@mapbox/sphericalmercator": "1.0.x",
     "minimist": "1.1.x"
   },


### PR DESCRIPTION
Bump version to `1.0.0`, drops windows support due to mapnik dropping windows support. Updates mapnik to `3.7.0`